### PR TITLE
use a fixed (4.0.8) version of Aerospike client

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Intro
 
-Scaerospike is a Scala wrapper around the Aerospike 3.x series asynchronous Java client. It uses the Scala 2.10 Futures
+Scaerospike is a Scala wrapper around the Aerospike 4.x series asynchronous Java client. It uses the Scala 2.10 Futures
 API.
 
 ## Getting started

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,8 +1,6 @@
+import sbt.Keys._
 import sbt._
-import Keys._
 import sbtrelease.ReleasePlugin._
-import sbtrelease._
-import ReleaseStateTransformations._
 
 object Scaerospike extends Build {
 
@@ -12,7 +10,7 @@ object Scaerospike extends Build {
       	organization := "com.tapad.scaerospike"
       ) ++ Seq(libraryDependencies ++=
         Seq(
-          "com.aerospike" % "aerospike-client" % "latest.integration",
+          "com.aerospike" % "aerospike-client" % "4.0.8",
           "org.scalatest" %% "scalatest" % "3.0.1" % "test"
         )
       )

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.7"
+version in ThisBuild := "1.2.8"


### PR DESCRIPTION
4.1.x version does not compile (caused by
https://github.com/aerospike/aerospike-client-java/commit/2abdd99)

also update README and bump version